### PR TITLE
Fix domain model typo in planning template

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -67,7 +67,7 @@ Produce a **single markdown plan** that a developer can hand to Copilot Chat wit
 
 ### Domain model
 
-* Refine the **Domain modal candidates** from Step-1 into a confirmed set of entities.
+* Refine the **Domain model candidates** from Step-1 into a confirmed set of entities.
 * Entities with fields/types, relationships, and invariants (bulleted).
 * Include **IDs**, **timestamps**, and validation rules.
 


### PR DESCRIPTION
## Summary
- Correct typo: change "Domain modal candidates" to "Domain model candidates" in planning template
- Confirm no other "modal" terminology mistakes across repository

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb57ec5a38832fac4cd6fb73dcbcd9