### PR TITLE
Clarify acceptance criteria handoff between steps

### DIFF
--- a/step-1-research.md
+++ b/step-1-research.md
@@ -66,7 +66,7 @@ For each slice, specify:
 * **Objective** (one sentence)
 * **Path** (UI/CLI → Route/Handler → Service → DB/External API → Response)
 * **Key contracts** to stabilize (DTOs, route signatures, DB tables)
-* **Acceptance criteria** (2–3 Given/When/Then bullets, incl. one negative)
+* **Draft acceptance criteria** (2–3 concise Given/When/Then bullets, incl. one negative) to be elaborated into full scenarios during Step 2
 * **Test notes** (what to assert; fixtures/mocks needed)
 
 ### Recommended Slice 1

--- a/step-2-plan.md
+++ b/step-2-plan.md
@@ -103,6 +103,7 @@ Create **6–8** Gherkin-style scenarios that are:
 
 * **Order-independent** and **data-isolated** (fresh fixtures per scenario).
 * **Incremental**: each scenario can pass after changing **one file**.
+* Expand the **draft acceptance criteria from Step 1** into full scenarios with precise Given/When/Then detail.
 * Include at least **2 negative/error cases** and **1 edge case**.
 * Example shape:
 


### PR DESCRIPTION
## Summary
- clarify in the Step 1 prompt that acceptance criteria are draft bullets that Step 2 will elaborate
- update Step 2 prompt instructions to explicitly expand Step 1 draft criteria into full scenarios

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d46d471a3c832fae9de7de7663003d