### PR TITLE
Enhance step prompts with stack and testing guidance

### DIFF
--- a/step-1-research.md
+++ b/step-1-research.md
@@ -46,8 +46,9 @@ You are my **product research analyst** and **technical due‑diligence partner*
 * **Comparable solutions / references:** 3–5 relevant apps, patterns, or repos with 1-line takeaways.
 * **Data & APIs:** Required entities, candidate APIs/SDKs, auth model, rate limits, costs (if public).
 * **Privacy & compliance (if applicable):** e.g., PII, GDPR/CCPA implications, logging.
-* **Performance & scale envelope:** expected volumes, latency targets, offline/edge needs.
-* **Constraints & dependencies:** platforms, runtimes, licenses, org blockers.
+* **Performance, quality & scale envelope:** expected volumes plus concrete latency/availability targets, baseline security posture, and monitoring/observability expectations (note offline/edge needs).
+* **Recommended stack options & rationale:** 1–2 pragmatic stacks mapped to constraints, existing assets, and team skills (call out trade-offs).
+* **Constraints & dependencies:** platforms, runtimes, licenses, org blockers, **engineering standards & tooling constraints** (mandated test runners, linters, CI/CD).
 
 ### MVP scope (first shippable)
 
@@ -66,7 +67,7 @@ For each slice, specify:
 * **Objective** (one sentence)
 * **Path** (UI/CLI → Route/Handler → Service → DB/External API → Response)
 * **Key contracts** to stabilize (DTOs, route signatures, DB tables)
-* **Draft acceptance criteria** (2–3 concise Given/When/Then bullets, incl. one negative) to be elaborated into full scenarios during Step 2
+* **Draft acceptance criteria** (2–3 concise Given/When/Then bullets, incl. one negative) **plus at least one detailed Gherkin skeleton or fixture/data setup that Step 2 must preserve**.
 * **Test notes** (what to assert; fixtures/mocks needed)
 
 ### Recommended Slice 1
@@ -81,7 +82,7 @@ For each slice, specify:
 
 ### Risks & unknowns
 
-* Top 5 risks with a mitigation/fallback each.
+* Top 5 risks with a mitigation/fallback each, including any surfaces likely to span multiple layers that might strain the “one cohesive surface” rule.
 
 ### Open questions (answer before planning)
 

--- a/step-2-plan.md
+++ b/step-2-plan.md
@@ -32,7 +32,7 @@ You are my **solution architect** and **build planner**. Convert the Step-1 rese
 
 Produce a **single markdown plan** that a developer can hand to Copilot Chat with minimal edits. The plan MUST:
 
-1. Pick a pragmatic **tech stack** consistent with constraints; if unclear, present two options with trade-offs and pick one.
+1. Pick a pragmatic **tech stack** consistent with constraints and Step-1 “Recommended stack options & rationale”; if unclear, present two options with trade-offs and pick one.
 2. Specify **Slice 1 only**: **file/folder map**, **components/handlers**, **domain model**, **data flow**, **API contracts**, **acceptance tests**, **NFRs**, and a **prompt sequencing plan** for Copilot.
 3. Call out **Assumptions**, **Open Questions**, **Risks**, and a short **Iteration Plan**.
 4. Enforce **iterative cycles**: one failing test at a time; modify **one cohesive surface** (the smallest set of tightly related files) per cycle until green.
@@ -103,7 +103,7 @@ Create **6–8** Gherkin-style scenarios that are:
 
 * **Order-independent** and **data-isolated** (fresh fixtures per scenario).
 * **Incremental**: each scenario can pass after changing **one cohesive surface** (usually 1–3 files that form a single interface boundary).
-* Expand the **draft acceptance criteria from Step 1** into full scenarios with precise Given/When/Then detail.
+* Expand the **draft acceptance criteria from Step 1** (including any supplied Gherkin skeletons or fixtures/data states) into full scenarios with precise Given/When/Then detail.
 * Include at least **2 negative/error cases** and **1 edge case**.
 * Example shape:
 
@@ -121,12 +121,12 @@ Scenario: {{validation failure}}
 
 ### Non-functional requirements (NFRs) for Slice 1
 
-* Concrete targets (e.g., API p95 < 200 ms locally, first render < 1s, basic a11y landmarks, input validation, structured logging). Keep to Slice 1.
+* Concrete targets (e.g., API p95 < 200 ms locally, first render < 1s, basic a11y landmarks, input validation, structured logging) aligned with Step-1 performance, availability, security, and monitoring expectations. Keep to Slice 1.
 
 ### Tooling & workflows
 
-* **Testing:** unit vs acceptance scope; coverage target (e.g., ≥80% lines for Slice 1 modules).
-* **Quality:** formatter, linter, type-checking, pre-commit (run lint+test).
+* **Testing:** unit vs acceptance scope; coverage target (e.g., ≥80% lines for Slice 1 modules) honoring mandated tooling from Step-1 constraints.
+* **Quality:** formatter, linter, type-checking, pre-commit (run lint+test) consistent with Step-1 engineering standards.
 * **CI (minimal):** install → lint → test; produce test report artifact.
 * **Run commands:**
 
@@ -169,7 +169,7 @@ Scenario: {{validation failure}}
 
 ### Risks & mitigations
 
-* List 3–5 risks specific to Slice 1 (e.g., hidden cross-surface dependencies break the cohesive-surface rule; flaky async tests; third-party API availability). Provide a concrete mitigation each.
+* List 3–5 risks specific to Slice 1 (e.g., hidden cross-surface dependencies break the cohesive-surface rule; flaky async tests; third-party API availability), explicitly addressing any multi-layer surfaces flagged in Step-1 Risks. Provide a concrete mitigation each.
 
 ### Open questions
 


### PR DESCRIPTION
## Summary
- expand the Step 1 research prompt to gather stack recommendations, engineering tooling standards, richer NFR guidance, detailed slice fixtures, and cross-surface risks
- align the Step 2 planning prompt to honor Step 1 recommendations, reuse supplied Gherkin skeletons/fixtures, and incorporate mandated tooling and multi-layer risks

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d5775536ec832faf20827e950fc692