### PR TITLE
Refine prompt handoff across PRD, TDD, and SBP templates

### DIFF
--- a/step-1-research.md
+++ b/step-1-research.md
@@ -8,7 +8,7 @@ Fill the bracketed fields. Paste this into ChatGPT **with web browsing on** and 
 
 > Copy from here ↓
 
-You are my **product research analyst** and **technical due‑diligence partner**. Produce a concise, evidence‑based Product Requirements Document (PRD) that will feed **Step‑2 Planning** and a Copilot‑driven, **vertical‑slice** build.
+You are my **product research analyst** and **technical due‑diligence partner**. Produce a concise, evidence‑based Product Requirements Document (PRD) that will feed **Step‑2 Design** and a Copilot‑driven, **vertical‑slice** build.
 
 ## Input (from me)
 

--- a/step-2-design.md
+++ b/step-2-design.md
@@ -2,7 +2,7 @@
 
 ## How to use
 
-Paste the new Step-2 template below into ChatGPT with your Step-1 output attached. Fill bracketed fields; leave unknowns blank. Run once to lock the design, then hand it to Copilot in VS Code. 
+Paste the new Step-2 template below into ChatGPT with your Step-1 output attached. Fill bracketed fields; leave unknowns blank. Run once to lock the design that Step 3 will turn into a slice-by-slice plan.
 
 ---
 
@@ -31,15 +31,15 @@ You are my **solution architect**. Convert the Step-1 research (PRD) into a **Co
 Produce a **single markdown plan** that a developer can hand to Copilot Chat with minimal edits. The plan MUST:
 
 1. Pick a pragmatic **tech stack** consistent with constraints and Step-1 “Recommended stack options & rationale”; if unclear, present two options with trade-offs and pick one.
-2. Specify **Slice 1 only**: **file/folder map**, **components/handlers**, **domain model**, **data flow**, **API contracts**, **acceptance tests**, **NFRs**, and a **prompt sequencing plan** for Copilot.
-3. Call out **Assumptions**, **Open Questions**, **Risks**, and a short **Iteration Plan**.
-4. Enforce **iterative cycles**: one failing test at a time; modify **one cohesive surface** (the smallest set of tightly related files) per cycle until green.
+2. Describe the end-to-end **system architecture**: **file/folder map**, **modules/components**, **data model**, **data flow**, and **interface contracts** that will support the entire MVP scope defined in Step 1.
+3. Capture **acceptance criteria** for the overall solution, cross-cutting **non-functional requirements**, and the engineering guardrails Copilot must respect when generating code.
+4. Call out **Assumptions**, **Open Questions**, **Risks**, and an **Iteration Readiness Checklist** that confirms the design is ready for Step 3 slice planning.
 
 ## Output format (markdown)
 
 ### Bottom line
 
-* One paragraph: exactly what will be shipped in the MVP, the chosen stack, and a breakdown of each vertical slice (in order of implementation). 
+* One paragraph: exactly what will be shipped in the MVP and the chosen stack, highlighting the primary capabilities the architecture must support (no slice planning yet).
 
 ### Architecture Overview
 
@@ -47,19 +47,22 @@ Produce a **single markdown plan** that a developer can hand to Copilot Chat wit
 * **App structure:** SPA/SSR/API-only/hybrid; state management approach if UI.
 * **Data storage:** what and why; migrations (if any).
 * **Auth:** method or “none”.
+* **Deployment & environments:** local dev workflow, CI/CD or manual deploy expectations.
 
 ### Tech Stack Decisions
 
-* Detail the recommended language/runtime, frameworks, databases and key libraries. 
+* Detail the recommended language/runtime, frameworks, databases and key libraries, with rationale and key configuration decisions.
 
 ### Interfaces
 
 * Detail the necessary API contracts, module contracts and event / telemetry contracts (as applicable).
+* Include inputs/outputs, validation rules, and error handling strategy.
 
 ### Domain model
 
 * Entities with fields/types, relationships, invariants, validations.
 * Always include **IDs** and **timestamps** where relevant.
+* Note persistence choices (e.g., tables, collections) and indexing considerations.
 
 ### Data flow & interfaces
 
@@ -68,7 +71,7 @@ Produce a **single markdown plan** that a developer can hand to Copilot Chat wit
 * Define concrete contracts for each interface:
 
 ```http
-POST /api/{{resource}}   // if applicable to Slice 1
+POST /api/{{resource}}   // if applicable to the MVP scope
 Request: { ...validated schema... }
 Response: { data|error }  // include error shape
 Limits: {{rate limits}} | Auth: {{scheme or none}}
@@ -76,12 +79,14 @@ Limits: {{rate limits}} | Auth: {{scheme or none}}
 
 ### Tooling & workflows
 
-* **Testing:** unit vs acceptance scope; coverage target (e.g., ≥80% lines for Slice 1 modules) honoring mandated tooling from Step-1 constraints.
+* **Testing:** unit vs acceptance scope; coverage target and types of automated tests honoring mandated tooling from Step-1 constraints.
 * **Quality:** formatter, linter, type-checking, pre-commit (run lint+test) consistent with Step-1 engineering standards.
+* **Collaboration:** branching strategy, code review expectations, docs to update.
 
 ### Risks & mitigations
 
 * List 3–5 risks. Provide a concrete mitigation for each.
+* Flag any design decisions that require validation with stakeholders.
 
 ### Assumptions
 
@@ -91,9 +96,13 @@ Limits: {{rate limits}} | Auth: {{scheme or none}}
 
 * Numbered list with resolution plan (owner/test/link). Proceed with **Assumptions** if blocks remain.
 
+### Iteration readiness checklist
+
+* Bullet list confirming the design gives Step 3 everything required: bounded MVP scope, clear contracts, defined dependencies, and any pre-work needed before slicing.
+
 ## Guardrails
 
-* Keep scope to **Slice 1**. Future features belong in Open questions or Iteration plan.
+* Keep scope at the **system design level**. Do not create slice-by-slice execution plans (that is Step 3’s responsibility).
 * **No silent scope changes**: require a “Change Request” to alter tests or add files.
 * Prefer batteries-included libs; default to local dev + single store.
 * All examples must run without external secrets unless specified.

--- a/step-3-plan.md
+++ b/step-3-plan.md
@@ -1,45 +1,112 @@
-# Step 3 - Planning Prompt
+# Step 3 — Slice Build Planning Prompt
 
 ## How to use
 
-Paste the PRD (Step 1 artifact) and the TDD (Step 2 artifact) into ChatGPT as attachments. Fill the bracketed fields detailing the slice that needs to be planned. Run this prompt and apply the instructions in Copilot in VS Code. 
+Run this prompt inside **GitHub Copilot Chat (Codex)** in VS Code with your repository open so the model has the live codebase plus the PRD (Step 1) and TDD (Step 2) as context. Fill in every bracketed field before sending it. Re-run after each slice ships or when the TDD changes.
 
 ---
 
 > Copy from here ↓
 
-You are my **senior developer** and **build planner**. Convert the TDD and the PRD into a copilot ready build plan that can be followed by me to build the next thin vertical slice for my application. The vertical-slice workflow is **tests-first** with **one failing test → declare one cohesive surface → make it pass**.
+You are my **senior developer** and **build planner**. Convert the PRD and TDD into a Copilot-ready Slice Build Plan (SBP) that I can follow to build the next thin vertical slices for this application. We ship with a **tests-first** workflow: write **one failing test**, define **one cohesive surface**, and drive it to green before moving on.
 
 ## Input (from me)
+
 * **Project name:** {{Name}}
 * **One-sentence objective:** {{Objective}}
-* **Step-1 artifact:** {{Paste or link the PRD}}
-* **Step-1 artifact:** {{Paste or link the TDD}}
-* **Stack/runtime:** {{e.g., FastAPI+Jinja+SQLite | Streamlit+SQLite | other as per TDD}}
-* **Repo state:** {{new repo | link}}
+* **Step-1 artifact (PRD):** {{Paste or link}}
+* **Step-2 artifact (TDD):** {{Paste or link}}
+* **Stack/runtime (confirm):** {{e.g., FastAPI+Jinja+SQLite}}
+* **Repo state:** {{new repo | branch | commit hash}}
+* **Slice window:** {{Slice numbers/names to plan now}}
+* **Known constraints since TDD:** {{New deadlines, integrations, refactors, bugs}}
 * **Depth:** {{brief | standard | deep}} (default: standard)
 
 ## What to do
 
-Produce a **single markdown plan** that a developer can hand to Copilot Chat with minimal edits. The plan MUST:
-1. Summarise the desired slice (0 or N). 
-2. Define the first failing test, the surface it exercises, and the conditions that make it pass. 
+Produce a **single markdown plan** that a developer can paste into Copilot Chat with minimal edits. The plan MUST:
+
+1. **Validate readiness**: restate the objective, confirm dependencies are satisfied, and list blockers or prerequisite work before coding.
+2. **Restate global guardrails** from the TDD (scope fences, quality bars, security/observability expectations) so Copilot operates safely inside them.
+3. **Define the slice window**: identify which slices will be executed now, why they matter, and how they relate.
+4. For **each slice** in the window, provide:
+   * Slice goal and completion definition.
+   * Preconditions/dependencies (including data seeds, migrations, or answers to open questions).
+   * Tests to author first (file names + test descriptions, failing assertion details).
+   * Touch-only files and the cohesive surface boundaries.
+   * Ordered Copilot prompt script (what to paste/ask, including context snippets or commands).
+   * Implementation checkpoints (what success looks like after each prompt or edit).
+   * Verification steps (tests/linters to run, manual QA) and telemetry/logging to confirm.
+   * Follow-up or cleanup tasks if time-boxed work leaves debt.
+5. **Summarize after-shipment actions**: documentation updates, deployment steps, or observations to capture for the next planning cycle.
 
 ## Output format (markdown)
 
-### Slice Plan — {{Project name}}
+### Slice Build Plan — {{Project name}}
 
-0) Plan Overview:
+0) Plan Overview
 
-* Stack: {{from TDD}}
-* Current codebase state: {{commit/tag or “new repo”}}
-* Window: slices planned now = {{Slice 0..2}} (re-plan after each shipment)
-* Policy: TDD contracts are frozen during this window; any change requires a TDD change first (Step-2) and then slice regeneration.
+* Objective recap: {{from inputs}}
+* Stack confirmation: {{from TDD}}
+* Current repo state: {{branch/commit}}
+* Slice window: {{list slices covered now}}
+* Prerequisites: {{list blocking tasks or "None"}}
 
-1) Global Guardrails (from TDD):
+1) Global Guardrails (from TDD)
 
-* Scope fence: Copilot may only modify files in each slice’s Touch-only list.
-* Quality gates: lint/format/test must pass; structured logs emit required events.
-* Security: input validation, secrets via .env, no PII in logs.
-* Observability: log {ts, level, event, request_id}; emit events listed per slice.
-* Config: local-first run; .env.example maintained.
+* Scope fence: {{files/services Copilot may modify}}
+* Quality gates: {{lint, format, test expectations}}
+* Security & privacy: {{input validation, secrets handling}}
+* Observability: {{required logs/metrics/events}}
+* Config & tooling: {{env files, scripts, automation}}
+
+2) Slice Window Summary
+
+| Slice | Objective | Depends on |
+| --- | --- | --- |
+| {{Slice ID}} | {{One-line goal}} | {{Prereqs or "None"}} |
+
+3) Slice Execution Plans
+
+#### Slice {{N}} — {{Slice name}}
+
+* **Goal:** {{What success delivers}}
+* **Definition of done:**
+  * {{Acceptance criterion 1}}
+  * {{Acceptance criterion 2}}
+* **Preconditions:** {{Data seeds, migrations, answers needed}}
+* **Touch-only files:** {{List directories/files Copilot may edit}}
+* **First failing test(s):**
+  * File: `{{path/to/test_file}}`
+  * Test name: `{{test_case_name}}`
+  * Failure setup: {{What assertion should fail initially}}
+* **Copilot prompt script:**
+  1. `{{Prompt text or command to send to Copilot}}`
+  2. `{{Next prompt}}`
+* **Implementation checkpoints:**
+  * {{Checkpoint 1}}
+  * {{Checkpoint 2}}
+* **Verification:**
+  * Command(s): `{{e.g., pytest tests/test_slice.py -k new_case}}`
+  * Manual QA: {{Steps}}
+  * Telemetry/logging: {{Events to confirm}}
+* **Follow-ups / debts:** {{Refactors, docs, tickets}}
+
+> Repeat the Slice section for every slice in the window.
+
+4) After-shipment actions
+
+* Documentation to update: {{README, ADRs, changelog}}
+* Deployment / release steps: {{Scripts or commands}}
+* Next review trigger: {{When to re-run Step 3}}
+
+## Guardrails
+
+* Stay aligned with the TDD; if a change is required, flag a **Design Change Request** back to Step 2 instead of altering scope here.
+* Assume Copilot writes all code—provide instructions, not diffs.
+* Keep prompts concise and sequential so Copilot can follow without additional clarification.
+* Prefer smallest viable slice; if the plan feels too large, split and recommend a narrower slice window.
+
+> End copy ↑
+
+---


### PR DESCRIPTION
## Summary
- align the Step 1 PRD prompt handoff language with the Step 2 design stage
- refocus the Step 2 TDD prompt on whole-system architecture and readiness for planning
- rewrite the Step 3 SBP prompt to drive Codex-based slice execution plans with detailed guidance

## Testing
- not run (markdown changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e044c88cf4832fb0135cffdd390c48